### PR TITLE
chore: Set up Dependabot with auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  # Rust dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore(deps)"
+    # Group minor and patch updates to reduce PR noise
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Summary

Configure Dependabot for automated dependency management with auto-merge for safe updates.

## Related Issue

Closes #13

## Changes Made

- Add `.github/dependabot.yml`:
  - Weekly Cargo dependency checks (Mondays)
  - Weekly GitHub Actions updates  
  - Group minor/patch updates to reduce PR noise
  - Labels: `dependencies`, `rust`
  - Commit prefix: `chore(deps)`

- Add `.github/workflows/dependabot-auto-merge.yml`:
  - Auto-approve and auto-merge **patch** and **minor** version updates only
  - **Major version updates require manual code review** (not auto-merged)
  - Uses squash merge strategy
  - Only triggers for `dependabot[bot]` PRs

## Test Plan

- [x] YAML syntax is valid
- [ ] Verify Dependabot creates PRs on next scheduled run
- [ ] Verify auto-merge works for minor/patch updates
- [ ] Verify major updates are NOT auto-merged

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally (`cargo test`)
- [x] Clippy passes (`cargo clippy --all-targets -- -D warnings`)
- [x] Documentation updated if needed
- [x] Breaking changes documented (if any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)