### PR TITLE
fix: Use trusted publishing for crates.io releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,19 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      dry_run:
+        description: 'Dry run (do not actually publish)'
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       dry_run:
         description: 'Dry run (do not actually publish)'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 env:
@@ -65,11 +72,14 @@ jobs:
           fi
           echo "Version verified: $CARGO_VERSION"
 
-  # Publish to crates.io
+  # Publish to crates.io using trusted publishing (OIDC)
   publish:
     name: Publish to crates.io
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -82,11 +92,16 @@ jobs:
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Dry run publish
-        if: github.event.inputs.dry_run == 'true'
+        if: inputs.dry_run == true
         run: cargo publish --dry-run
 
+      - name: Authenticate with crates.io
+        if: inputs.dry_run != true
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish to crates.io
-        if: github.event.inputs.dry_run != 'true'
+        if: inputs.dry_run != true
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # Required for trusted publishing to crates.io
 
 jobs:
   create-tag:
@@ -83,3 +84,13 @@ jobs:
             hemmer-provider-sdk = "${{ steps.extract.outputs.version }}"
             ```
           generate_release_notes: true
+
+  # Publish to crates.io after creating the release (using trusted publishing)
+  publish:
+    needs: create-tag
+    uses: ./.github/workflows/publish.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      dry_run: false


### PR DESCRIPTION
## Summary
- Switch from API token to OIDC-based trusted publishing
- Use `rust-lang/crates-io-auth-action@v1` for authentication
- Add `id-token: write` permission for OIDC token requests
- Remove `CRATES_IO_TOKEN` secret requirement from workflows

## Benefits
- **More secure**: No long-lived API tokens stored in repository secrets
- **Short-lived tokens**: 30-minute validity, auto-revoked after job completion
- **No manual token management**: OIDC handles authentication automatically

## Setup Required
Before merging, you need to configure trusted publishing on crates.io:
1. Go to https://crates.io/crates/hemmer-provider-sdk/settings
2. Add a new "Trusted Publisher" for GitHub Actions
3. Configure:
   - Repository owner: `hemmer-io`
   - Repository name: `hemmer-provider-sdk`
   - Workflow filename: `publish.yml`
   - Environment: (leave blank)

## Test Plan
- [ ] Configure trusted publishing on crates.io
- [ ] Test with next release

## References
- [crates.io Trusted Publishing docs](https://crates.io/docs/trusted-publishing)
- [RFC 3691](https://rust-lang.github.io/rfcs/3691-trusted-publishing-cratesio.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)