### PR TITLE
feat: Add automatic plan diff computation utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `PlanResult::from_diff()` method for automatic plan diff computation (#32)
+  - Automatically computes attribute changes by comparing prior and proposed states
+  - Eliminates need for manual `AttributeChange` construction in providers
+  - Supports nested objects with dot-notation paths (e.g., `"metadata.labels.app"`)
+  - Supports arrays with bracket notation (e.g., `"tags[0]"`)
+  - Comprehensive test coverage for various diff scenarios
+
 ## [0.2.0] - 2025-11-29
 
 ### Added


### PR DESCRIPTION
## Summary

This PR implements automatic plan diff computation for provider implementations, addressing the need to eliminate manual `AttributeChange` construction across all providers.

## Related Issue

Closes #32

## Changes Made

- Added `PlanResult::from_diff()` method for automatic diff computation
  - Recursively compares prior and proposed JSON states
  - Generates `AttributeChange` entries for all differences
  - Supports nested objects with dot-notation paths (e.g., `"metadata.labels.app"`)
  - Supports arrays with bracket notation (e.g., `"tags[0]"`)
- Added helper functions:
  - `collect_all_fields()` - marks all fields as additions when creating resources
  - `compute_json_diff()` - recursively computes differences between two JSON values
- Added comprehensive documentation:
  - Doc comments with usage examples
  - README section with best practices
  - CHANGELOG entry under [Unreleased]
- Added 15 test cases covering:
  - Resource creation (simple, nested, arrays)
  - No changes detection
  - Simple and nested modifications
  - Field additions and removals
  - Array modifications (add, remove, modify elements)
  - Complex nested structures
  - Type changes

## Benefits

1. **DRY**: Single implementation used by all providers
2. **Consistency**: All providers compute diffs the same way
3. **Maintainability**: Bug fixes and improvements in one place
4. **Simplicity**: Providers just call `PlanResult::from_diff(prior, proposed)`

## Test Plan

- [x] All existing tests pass
- [x] 15 new test cases for diff computation scenarios
- [x] Doc tests verify examples compile and run correctly
- [x] Clippy passes with no warnings
- [x] Code is properly formatted

## Example Usage

### Before (Manual)
```rust
async fn plan(&self, ...) -> Result<PlanResult, ProviderError> {
    let mut changes = Vec::new();
    
    if prior.get("name") != proposed.get("name") {
        changes.push(AttributeChange::modified("name", 
            prior["name"].clone(), 
            proposed["name"].clone()
        ));
    }
    
    // ... manually check every field ...
    
    Ok(PlanResult::with_changes(proposed, changes, false))
}
```

### After (Automatic)
```rust
async fn plan(&self, ...) -> Result<PlanResult, ProviderError> {
    Ok(PlanResult::from_diff(prior_state.as_ref(), &proposed_state))
}
```

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally (`cargo test`)
- [x] Clippy passes (`cargo clippy --all-targets -- -D warnings`)
- [x] Documentation updated (README, CHANGELOG)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)