### PR TITLE
feat: Add comprehensive ProviderError variants for gRPC status mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Additional `ProviderError` variants for comprehensive gRPC status mapping (#35)
+  - `AlreadyExists` - Resource already exists (create conflict)
+  - `PermissionDenied` - Permission denied (authentication/authorization failure)
+  - `ResourceExhausted` - Quota or rate limit exceeded
+  - `Unavailable` - Service temporarily unavailable
+  - `DeadlineExceeded` - Operation timed out
+  - `FailedPrecondition` - Operation failed due to current state (precondition not met)
+  - `Unimplemented` - Operation not implemented
+  - Updated `From<ProviderError> for tonic::Status` with new variant mappings
+  - Comprehensive test coverage for all new error variants
+
 ## [0.2.1] - 2025-11-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -251,6 +251,49 @@ if is_valid(&schema, &value) {
 }
 ```
 
+## Error Handling
+
+The SDK provides a comprehensive `ProviderError` enum that maps to appropriate gRPC status codes:
+
+```rust
+use hemmer_provider_sdk::ProviderError;
+
+// Resource not found (maps to NOT_FOUND)
+return Err(ProviderError::NotFound("instance-123 not found".to_string()));
+
+// Resource already exists (maps to ALREADY_EXISTS)
+return Err(ProviderError::AlreadyExists("bucket my-bucket already exists".to_string()));
+
+// Permission/auth errors (maps to PERMISSION_DENIED)
+return Err(ProviderError::PermissionDenied("insufficient permissions to delete resource".to_string()));
+
+// Rate limiting or quota errors (maps to RESOURCE_EXHAUSTED)
+return Err(ProviderError::ResourceExhausted("API rate limit exceeded".to_string()));
+
+// Temporary service issues (maps to UNAVAILABLE)
+return Err(ProviderError::Unavailable("service temporarily unavailable".to_string()));
+
+// Timeout errors (maps to DEADLINE_EXCEEDED)
+return Err(ProviderError::DeadlineExceeded("operation timed out after 30s".to_string()));
+
+// State precondition failures (maps to FAILED_PRECONDITION)
+return Err(ProviderError::FailedPrecondition("resource must be stopped before deletion".to_string()));
+
+// Unimplemented operations (maps to UNIMPLEMENTED)
+return Err(ProviderError::Unimplemented("import not supported for this resource type".to_string()));
+
+// Validation errors (maps to INVALID_ARGUMENT)
+return Err(ProviderError::Validation("invalid instance size".to_string()));
+
+// Configuration errors (maps to FAILED_PRECONDITION)
+return Err(ProviderError::Configuration("missing required API key".to_string()));
+```
+
+Using the appropriate error variant enables:
+- **Better UX**: Users see meaningful error messages
+- **Retry Logic**: Clients can retry on `Unavailable` but not `NotFound`
+- **Debugging**: Error codes help identify root causes quickly
+
 ## Testing
 
 The SDK includes a test harness for provider implementations:


### PR DESCRIPTION
## Summary

Adds seven new `ProviderError` variants to enable comprehensive gRPC status code mapping, allowing providers to return semantically appropriate errors for different scenarios.

## Related Issue

Closes #35

## Changes Made

### Error Variants Added
- `AlreadyExists` - Resource already exists (create conflict)
- `PermissionDenied` - Permission denied (authentication/authorization failure)
- `ResourceExhausted` - Quota or rate limit exceeded
- `Unavailable` - Service temporarily unavailable
- `DeadlineExceeded` - Operation timed out
- `FailedPrecondition` - Operation failed due to current state
- `Unimplemented` - Operation not implemented

### Implementation
- Added 7 new error variants to `ProviderError` enum in `src/error.rs`
- Updated `From<ProviderError> for tonic::Status` with proper gRPC status code mappings
- Added comprehensive test coverage:
  - `test_new_error_variants_display()` - Validates error message formatting
  - `test_new_error_variants_to_status()` - Validates gRPC status code mappings

### Documentation
- Added **Error Handling** section to README.md with:
  - Usage examples for all error variants
  - gRPC status code mapping information
  - Guidance on when to use each variant
  - Benefits explanation (UX, retry logic, debugging)
- Updated CHANGELOG.md with detailed change description

## Motivation

This change enables:
1. **Better UX**: Users see meaningful errors ("bucket already exists" vs "internal error")
2. **Retry Logic**: Clients can retry on `Unavailable` but not `NotFound`
3. **Debugging**: Error codes help identify issues quickly
4. **API Quality**: Follows gRPC best practices

## Test Plan

- [x] All existing tests pass (70 unit tests)
- [x] New error variant display tests pass
- [x] New error variant status conversion tests pass
- [x] Documentation tests pass
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings
- [x] Pre-commit hooks pass

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally (`cargo test`)
- [x] Clippy passes (`cargo clippy --all-targets -- -D warnings`)
- [x] Documentation updated (README.md and CHANGELOG.md)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)